### PR TITLE
Fix status code parsing

### DIFF
--- a/fastwarc/warc.pyx
+++ b/fastwarc/warc.pyx
@@ -202,7 +202,7 @@ cdef class WarcHeaderMap:
         """
         if self._status_line.find(<char*>b'HTTP/') != 0:
             return None
-        s = self._status_line.split(b' ')
+        s = self._status_line.split(b' ', 2)
         if len(s) != 3 or not s[1].isdigit():
             return None
         return int(s)


### PR DESCRIPTION
See Issue #3, fix the parsing of a HTTP header status line. The reason phrase may contain spaces.