### PR TITLE
Fix typo in write() causing failure if unparsed data is written

### DIFF
--- a/fastwarc/warc.pyx
+++ b/fastwarc/warc.pyx
@@ -602,7 +602,7 @@ cdef class WarcRecord:
         :rtype: int
         """
         # If the raw byte content hasn't been parsed, we can simply pass it through
-        if not checksum_data and not self.http_parsed:
+        if not checksum_data and not self._http_parsed:
             return self._write_impl(self.reader, stream, True, chunk_size)
 
         # Otherwise read everything into memory for content-length correction and checksumming


### PR DESCRIPTION
A typo in the write() method causes a failure if unparsed data is written and no checksum is calculated, eg. by using the `recompress` subcommand:
```
AttributeError: 'fastwarc.warc.WarcRecord' object has no attribute 'http_parsed'
Exception ignored in: 'fastwarc.warc.WarcRecord.write'
```