### PR TITLE
FastWARC: command-line tools to index and extract WARC records

### DIFF
--- a/docs/man/fastwarc-cli.rst
+++ b/docs/man/fastwarc-cli.rst
@@ -18,6 +18,8 @@ Besides the :ref:`Python API <fastwarc-manual>`, FastWARC also provides a comman
   Commands:
     benchmark   Benchmark FastWARC performance.
     check       Verify WARC consistency by checking all digests.
+    extract     Extract WARC record by offset.
+    index       Index WARC records as CDXJ.
     recompress  Recompress a WARC file with different settings.
 
 Check Digests
@@ -42,6 +44,26 @@ If your WARC is uncompressed or not compressed properly at the record-level or y
 
 
 Run ``fastwarc recompress --help`` for a full help listing.
+
+Extract Records by Offset
+-------------------------
+You can extract individual records at a given byte offset with either just headers, payload, or both:
+
+.. code-block:: bash
+
+  fastwarc extract [--headers] [--payload] [--output] INFILE OFFSET
+
+Run ``fastwarc extract --help`` for a full help listing.
+
+Index Records as CDXJ
+---------------------
+WARC files can be indexed to the `CDXJ <https://github.com/webrecorder/cdxj-indexer>`_ format with a configurable set of fields:
+
+.. code-block::
+
+  fastwarc index [--fields FIELDS] [--preserve-multi-header] [--output] [INFILES]...
+
+Run ``fastwarc index --help`` for a full help listing.
 
 Benchmark FastWARC vs. WARCIO
 -----------------------------

--- a/fastwarc/fastwarc/cli.py
+++ b/fastwarc/fastwarc/cli.py
@@ -196,8 +196,10 @@ def extract(infile, offset, output, payload, headers):
                 while buf:
                     output.write(buf)
                     buf = record.reader.read(4096)
+        except StopIteration:
+            pass
         except Exception as e:
-            sys.stderr.write('Failed to extract WARC record at offset %d: %s\n' % (offset, e))
+            sys.stderr.write('Failed to extract WARC record at offset {}: {}\n'.format(offset, e))
 
 @main.group()
 def benchmark():

--- a/fastwarc/fastwarc/warc.pxd
+++ b/fastwarc/fastwarc/warc.pxd
@@ -43,7 +43,7 @@ cdef class WarcHeaderMap:
     cdef dict _dict_cache
     cdef bint _dict_cache_stale
 
-    cdef size_t write(self, IOStream stream) except -1
+    cpdef size_t write(self, IOStream stream) except -1
     cpdef void clear(self)
     cdef inline void set_status_line(self, const string& status_line)
     cdef string find_header(self, const string& header_key, const string& default)

--- a/fastwarc/fastwarc/warc.pyx
+++ b/fastwarc/fastwarc/warc.pyx
@@ -115,24 +115,24 @@ class CaseInsensitiveStrDict(dict):
         super().__init__(*args, **kwargs)
         self._header_obj = None
 
-    def __getitem__(self, str key not None):
+    def __getitem__(self, key not None):
         return super().__getitem__(CaseInsensitiveStr(key))
 
-    def __setitem__(self, str key not None, str value not None):
+    def __setitem__(self, key not None, value not None):
         super().__setitem__(CaseInsensitiveStr(key), value)
         if self._header_obj is not None:
             self._header_obj[key] = value
 
-    def __contains__(self, str key not None):
+    def __contains__(self, key not None):
         return super().__contains__(CaseInsensitiveStr(key))
 
-    def get(self, str key not None, str value=None):
+    def get(self, key not None, value=None):
         return super().get(CaseInsensitiveStr(key), value)
 
-    def setdefault(self, str key not None, str value=None):
+    def setdefault(self, key not None, value=None):
         return super().setdefault(CaseInsensitiveStr(key), value)
 
-    def pop(self, str key not None):
+    def pop(self, key not None):
         return super().pop(CaseInsensitiveStr(key))
 
     def update(self, it=None, **kwargs):
@@ -188,8 +188,8 @@ cdef class WarcHeaderMap:
         :rtype: t.Iterable[(str, str)]
         """
         cdef str_pair h
-        yield from ((h[0].decode(self._enc, errors='ignore'), h[1].decode(self._enc, errors='ignore'))
-                    for h in self._headers)
+        yield from ((CaseInsensitiveStr(h[0].decode(self._enc, errors='ignore')),
+                     h[1].decode(self._enc, errors='ignore')) for h in self._headers)
 
     def __repr__(self):
         return repr(self.astuples())
@@ -224,7 +224,7 @@ cdef class WarcHeaderMap:
         return self._status_line.decode(self._enc, errors='ignore')
 
     @status_line.setter
-    def status_line(self, str status_line not None):
+    def status_line(self, status_line not None):
         """
         Set status line contents.
 
@@ -247,7 +247,7 @@ cdef class WarcHeaderMap:
             return None
         return int(s[1])
 
-    def append(self, str key not None, str value not None):
+    def append(self, key not None, value not None):
         """
         append(self, key, value)
 
@@ -262,7 +262,7 @@ cdef class WarcHeaderMap:
         value = value.replace('\r\n', ' ').replace('\n', ' ').strip()
         self.append_header(key.encode(self._enc), value.encode(self._enc))
 
-    def get(self, str key not None, str default=None) -> str:
+    def get(self, key not None, default=None) -> str:
         """
         get(self, key, default=None)
 
@@ -573,7 +573,7 @@ cdef class WarcRecord:
     @property
     def content_length(self) -> int:
         """
-        Remaining WARC length in bytes (not necessarily the same as the ``Content-Length`` header).
+        Remaining WARC record length in bytes (not necessarily the same as the ``Content-Length`` header).
 
         :type: int
         """

--- a/fastwarc/fastwarc/warc.pyx
+++ b/fastwarc/fastwarc/warc.pyx
@@ -362,7 +362,7 @@ cdef class WarcHeaderMap:
         self._status_line.clear()
         self._dict_cache_stale = True
 
-    cdef size_t write(self, IOStream stream) except -1:
+    cpdef size_t write(self, IOStream stream) except -1:
         """Write header block into stream."""
         cdef size_t bytes_written = 0
         if not self._status_line.empty():


### PR DESCRIPTION
Command-line tools to index and extract WARC records are useful to quickly inspect WARC files. The implemented tools/commands behave almost the same as [warcio index](//github.com/webrecorder/warcio#index) and [warcio extract](//github.com/webrecorder/warcio#extract). One difference is for example that `warcio extract` decodes the record payload, removing HTTP transfer and content encoding. Only local files are supported for now because `seek()` and `tell()` are required (would need some efforts to support URLs as well).

```
$> fastwarc index --help
Usage: fastwarc index [OPTIONS] [INFILES]...

  Index WARC records into CDXJ.

Options:
  -o, --output FILENAME  Output file, default is stdout
  -f, --fields TEXT      comma-separated list of indexed fields, eg. "offset",
                         "length", "filename", "http:status", "http:<http-
                         header>", or "<warc-record-header>"

  -h, --help             Show this message and exit.

$> wget http://commoncrawl.s3.amazonaws.com/crawl-data/CC-NEWS/2021/09/CC-NEWS-20210930113548-00741.warc.gz

$> fastwarc index -fwarc-type,http:status,warc-target-uri,filename,offset,length CC-NEWS-20210930113548-00741.warc.gz | head -3
{"warc-type": "warcinfo", "filename": "CC-NEWS-20210930113548-00741.warc.gz", "offset": "0", "length": "423"}
{"warc-type": "request", "warc-target-uri": "https://www.novinite.com/articles/211500/Accident+with+Stranded+Ship+Vera+Su+Might+Be+Caused+by+Inexperienced+Crew+Member", "filename": "CC-NEWS-20210930113548-00741.warc.gz", "offset": "423", "length": "508"}
{"warc-type": "response", "http:status": 200, "warc-target-uri": "https://www.novinite.com/articles/211500/Accident+with+Stranded+Ship+Vera+Su+Might+Be+Caused+by+Inexperienced+Crew+Member", "filename": "CC-NEWS-20210930113548-00741.warc.gz", "offset": "931", "length": "12680"}
```

```
$> fastwarc extract --help
Usage: fastwarc extract [OPTIONS] INFILE OFFSET

  Extract WARC record by offset.

Options:
  --payload   output only record payload (transfer and/or content encoding are
              preserved

  --headers   output only record (and HTTP) headers
  -h, --help  Show this message and exit.

$> fastwarc extract --headers CC-NEWS-20210930113548-00741.warc.gz 931
WARC/1.0
WARC-Record-ID: <urn:uuid:cefe66f5-6ed7-4e2c-839a-964bbfb9fcf2>
Content-Length: 44827
WARC-Date: 2021-09-30T11:35:47Z
WARC-Type: response
WARC-Target-URI: https://www.novinite.com/articles/211500/Accident+with+Stranded+Ship+Vera+Su+Might+Be+Caused+by+Inexperienced+Crew+Member
Content-Type: application/http; msgtype=response
WARC-Payload-Digest: sha1:ICXB6ZRV3DBDGIQJJUFAFM5HBXN574BH
WARC-Block-Digest: sha1:6NYQONX4OQBGVVGCUJYDQ4S7EBAYWH6R

HTTP/1.1 200 OK
Date: Thu, 30 Sep 2021 11:35:48 GMT
Server: Apache/2.4.10 (Debian)
Set-Cookie: PHPSESSID=kbh1betq8no20aeofgpjsnpj64; path=/
Expires: Thu, 19 Nov 1981 08:52:00 GMT
Cache-Control: no-store, no-cache, must-revalidate, post-check=0, pre-check=0
Pragma: no-cache
Vary: Accept-Encoding
X-Crawler-Content-Encoding: gzip
X-Crawler-Content-Length: 12159
Content-Length: 44350
Keep-Alive: timeout=5, max=100
Connection: Keep-Alive
Content-Type: text/html

$> fastwarc extract --payload CC-NEWS-20210930113548-00741.warc.gz 931 | head -7
<!DOCTYPE html>

<html>
<head>
        <base href="https://www.novinite.com/">
        <META http-equiv="Content-Type" content="text/html; charset=utf-8">
        <title>Accident with Stranded Ship Vera Su Might Be Caused by Inexperienced Crew Member - Novinite.com - Sofia News Agency</title>
```