### PR TITLE
Fix Windows DLL bundling

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -44,8 +44,9 @@ jobs:
         DYLD_LIBRARY_PATH=$LIBRARY_PATH delocate-listdeps {wheel} &&
         DYLD_LIBRARY_PATH=$LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
 
-#      CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
-#      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair --add-path C:\\vcpkg\\installed\\x64-windows\\lib -w {dest_dir} {wheel}"
+      CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
+        delvewheel repair --add-path C:\vcpkg\installed\x64-windows\bin -w {dest_dir} {wheel}
 
       CPATH: /usr/local/share/vcpkg/installed/x64-osx/include
       LIBRARY_PATH: /usr/local/share/vcpkg/installed/x64-osx/lib


### PR DESCRIPTION
Windows wheels were broken due to missing DLLs.