### PR TITLE
Build ASAN config

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -123,11 +123,42 @@ jobs:
           name: sdist
           path: ./dist/*.tar.gz
 
+  build-asan:
+    runs-on: ubuntu-latest
+    container:
+      image: webis/resiliparse-manylinux2014_x86_64
+    env:
+      TRACE: "1"
+      ASAN: "1"
+      ASAN_OPTIONS: detect_leaks=0
+      PYTHON: /opt/python/cp310-cp310/bin/python
+      PYTHONPATH: resiliparse:fastwarc
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Install Build Dependencies
+        run: $PYTHON -m pip install cython
+
+      - name: Build Extensions Inline
+        run: |
+          set -e
+          (cd fastwarc && $PYTHON setup.py develop build_ext --debug --inplace easy_install "fastwarc[all,test]")
+          (cd resiliparse && $PYTHON setup.py develop build_ext --debug --inplace easy_install "resiliparse[all,test]")
+
+      - name: Run Tests
+        run: |
+          export LD_PRELOAD="$(ldconfig -p | grep libasan | head -n1 | awk '{print $4}')"
+          $PYTHON -m pytest --capture=sys tests/
+
   build-coverage:
     runs-on: ubuntu-latest
     container:
       image: webis/resiliparse-manylinux2014_x86_64
-    needs: [ build-wheels, build-sdist ]
+    needs: [ build-wheels, build-asan, build-sdist ]
     env:
       TRACE: "1"
       PYTHON: /opt/python/cp39-cp39/bin/python
@@ -145,8 +176,8 @@ jobs:
       - name: Build Extensions Inline
         run: |
           set -e
-          (cd fastwarc && $PYTHON setup.py build_ext --inplace && $PYTHON -m pip install -e ".[all,test]")
-          (cd resiliparse && $PYTHON setup.py build_ext --inplace && $PYTHON -m pip install -e ".[all,test]")
+          (cd fastwarc && $PYTHON setup.py develop build_ext --inplace easy_install "fastwarc[all,test]")
+          (cd resiliparse && $PYTHON setup.py develop build_ext --inplace easy_install "resiliparse[all,test]")
 
       - name: Run Tests
         run: $PYTHON -m pytest --cov=resiliparse/ --cov=fastwarc/ --cov=resiliparse_common/ --cov-report xml tests/

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -128,10 +128,10 @@ jobs:
     container:
       image: webis/resiliparse-manylinux2014_x86_64
     env:
-      TRACE: "1"
+      DEBUG: "1"
       ASAN: "1"
       ASAN_OPTIONS: detect_leaks=0
-      PYTHON: /opt/python/cp310-cp310/bin/python
+      PYTHON: /opt/python/cp39-cp39/bin/python
       PYTHONPATH: resiliparse:fastwarc
 
     steps:
@@ -146,8 +146,8 @@ jobs:
       - name: Build Extensions Inline
         run: |
           set -e
-          (cd fastwarc && $PYTHON setup.py develop build_ext --debug --inplace easy_install "fastwarc[all,test]")
-          (cd resiliparse && $PYTHON setup.py develop build_ext --debug --inplace easy_install "resiliparse[all,test]")
+          $PYTHON -m pip install -e "fastwarc[all,test]"
+          $PYTHON -m pip install -e "resiliparse[all,test]"
 
       - name: Run Tests
         run: |
@@ -176,8 +176,8 @@ jobs:
       - name: Build Extensions Inline
         run: |
           set -e
-          (cd fastwarc && $PYTHON setup.py develop build_ext --inplace easy_install "fastwarc[all,test]")
-          (cd resiliparse && $PYTHON setup.py develop build_ext --inplace easy_install "resiliparse[all,test]")
+          $PYTHON -m pip install -e "fastwarc[all,test]"
+          $PYTHON -m pip install -e "resiliparse[all,test]"
 
       - name: Run Tests
         run: $PYTHON -m pytest --cov=resiliparse/ --cov=fastwarc/ --cov=resiliparse_common/ --cov-report xml tests/

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,9 @@ RUN set -x \
     && rm -rf lexbor
 
 RUN set -x \
-    && yum install -y zlib-devel lz4-devel uchardet-devel re2-devel
+    && yum install -y \
+          devtoolset-10-libasan-devel \
+          lz4-devel \
+          re2-devel \
+          uchardet-devel \
+          zlib-devel

--- a/fastwarc/setup.py
+++ b/fastwarc/setup.py
@@ -41,15 +41,15 @@ try:
     ext = 'pyx'
     cython_args = dict(
         annotate=DEBUG,
-        language_level='3',
+        gdb_debug=DEBUG,
         compiler_directives=dict(
+            language_level='3',
             linetrace=TRACE,
             initializedcheck=DEBUG,
             boundscheck=DEBUG,
             cdivision=True
         )
     )
-
     USE_CYTHON = True
 except ModuleNotFoundError as e:
     pass
@@ -60,11 +60,8 @@ if TRACE:
 
 if CXX == 'unix':
     cpp_args.update(dict(
-        extra_compile_args=['-std=c++17', '-O3', '-Wno-deprecated-declarations',
-                            '-Wno-unreachable-code', '-Wno-unused-function',
-                            # Temporary flags until https://github.com/lexbor/lexbor/pull/125 and
-                            # https://github.com/lexbor/lexbor/pull/135 are released
-                            '-fpermissive', '-Wno-c++11-narrowing'],
+        extra_compile_args=['-std=c++17', f'-O{0 if DEBUG else 3}', '-Wno-deprecated-declarations',
+                            '-Wno-unreachable-code', '-Wno-unused-function'],
         extra_link_args=['-std=c++17']
     ))
     if ASAN:

--- a/resiliparse/resiliparse/extract/html2text.pyx
+++ b/resiliparse/resiliparse/extract/html2text.pyx
@@ -164,10 +164,10 @@ cdef void _extract_cb(vector[shared_ptr[ExtractNode]]& extract_nodes, ExtractCon
         last_node.collapse_margins = False
 
     elif ctx.opts.links and is_end_tag and ctx.node.local_name == LXB_TAG_A:
-        element_text_sv = <string>get_node_attr_sv(ctx.node, b'href')
+        element_text_sv = get_node_attr_sv(ctx.node, b'href')
         if not element_text_sv.empty():
             element_text.append(b' (')
-            element_text.append(<string> element_text_sv)
+            element_text.append(<string>element_text_sv)
             element_text.append(b') ')
             _ensure_text_contents(extract_nodes)
             deref(last_node.text_contents).append(element_text)

--- a/resiliparse/setup.py
+++ b/resiliparse/setup.py
@@ -43,8 +43,9 @@ try:
     ext = 'pyx'
     cython_args = dict(
         annotate=DEBUG,
-        language_level='3',
+        gdb_debug=DEBUG,
         compiler_directives=dict(
+            language_level='3',
             linetrace=TRACE,
             initializedcheck=DEBUG,
             boundscheck=DEBUG,
@@ -61,11 +62,8 @@ if TRACE:
 
 if CXX == 'unix':
     cpp_args.update(dict(
-        extra_compile_args=['-std=c++17', '-O3', '-Wno-deprecated-declarations',
-                            '-Wno-unreachable-code', '-Wno-unused-function',
-                            # Temporary flags until https://github.com/lexbor/lexbor/pull/125 and
-                            # https://github.com/lexbor/lexbor/pull/135 are released
-                            '-fpermissive', '-Wno-c++11-narrowing'],
+        extra_compile_args=['-std=c++17', f'-O{0 if DEBUG else 3}', '-Wno-deprecated-declarations',
+                            '-Wno-unreachable-code', '-Wno-unused-function'],
         extra_link_args=['-std=c++17']
     ))
     if ASAN:

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+markers =
+    slow: marks tests as slow (deselect with '-m "not slow"')
+python_classes = !TestPipeline

--- a/tests/resiliparse/test_process_guard.py
+++ b/tests/resiliparse/test_process_guard.py
@@ -100,7 +100,6 @@ def wait_func_exc_progress():
 
 
 # noinspection PyUnreachableCode
-@pytest.mark.serial
 @pytest.mark.slow
 def test_time_guard():
     with pytest.raises(ExecutionTimeout):
@@ -193,7 +192,6 @@ def fill_mem_signal_term():
             pass
 
 
-@pytest.mark.serial
 @pytest.mark.slow
 def test_mem_guard():
     if platform.system() != 'Linux':


### PR DESCRIPTION
Add a separate CI job that builds with ASAN enabled.

Also fixes a stack-use-after-scope error in `resiliparse.html2text.extract_plain_text`.

Test PR to trigger CI.