### PR TITLE
CLI index: fix exception when determining the length of the last WARC record

### DIFF
--- a/fastwarc/fastwarc/cli.py
+++ b/fastwarc/fastwarc/cli.py
@@ -280,7 +280,7 @@ def index(infiles, output, fields, preserve_multi_header):
                 prev_record = record
 
             if prev_record is not None:
-                _index_record(output, fields, preserve_multi_header, prev_record, prev_record.reader.tell(), infile)
+                _index_record(output, fields, preserve_multi_header, prev_record, stream.tell(), infile)
 
 
 boto3 = None


### PR DESCRIPTION
Use tell() on underlying stream (instead of fastwarc stream_io reader) to determine the file offset after last WARC record has been read. Fixes the following exception which also causes that the last WARC record is not indexed:

```
Traceback (most recent call last):
  File "/usr/local/bin/fastwarc", line 8, in <module>
    sys.exit(main())
  ...
  File "/usr/local/lib/python3.10/dist-packages/fastwarc/cli.py", line 283, in index
    _index_record(output, fields, preserve_multi_header, prev_record, prev_record.reader.tell(), infile)
  File "fastwarc/warc.pyx", line 704, in fastwarc.warc.WarcRecord.reader.__get__
  File "fastwarc/warc.pyx", line 491, in fastwarc.warc.WarcRecord._assert_not_stale
fastwarc.stream_io.ReaderStaleError: Reader is stale. Use freeze() if you want to retain record payload.
```