### PR TITLE
Upgrade GitHub Action checkout to v4

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3  # TODO: Upgrade to v4 causes GLIBC failures
+        uses: actions/checkout@v3  # TODO: Upgrade to @v4 causes GLIBC failures
         with:
           fetch-depth: 0
 
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3  # TODO: Upgrade to @v4 causes GLIBC failures
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Vcpkg
         uses: actions/cache@v3
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -190,7 +190,7 @@ jobs:
     needs: build-wheels
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3  # TODO: Upgrade to v4 causes GLIBC failures
         with:
           fetch-depth: 0
 

--- a/fastwarc/setup.py
+++ b/fastwarc/setup.py
@@ -14,14 +14,12 @@
 
 import os
 import sys
-import warnings
 
 from Cython.Build import cythonize
 from Cython.Distutils.build_ext import new_build_ext as build_ext
 import distutils.ccompiler
 from distutils.dir_util import copy_tree
 from setuptools import Extension, setup
-from setuptools.config import pyprojecttoml
 
 TRACE = bool(int(os.getenv('TRACE', 0)))
 DEBUG = bool(int(os.getenv('DEBUG', 0))) or TRACE
@@ -30,8 +28,6 @@ ASAN = bool(int(os.getenv('ASAN', 0)))
 ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 CXX = distutils.ccompiler.get_default_compiler()
 
-# noinspection PyProtectedMember
-warnings.simplefilter('ignore', pyprojecttoml._BetaConfiguration)
 
 def get_cpp_args():
     cpp_args = {}

--- a/resiliparse/setup.py
+++ b/resiliparse/setup.py
@@ -17,13 +17,11 @@ import os
 import platform
 import shutil
 import sys
-import warnings
 
 from Cython.Build import cythonize
 from Cython.Distutils.build_ext import new_build_ext as build_ext
 import distutils.ccompiler
 from setuptools import Extension, setup
-from setuptools.config import pyprojecttoml
 
 TRACE = bool(int(os.getenv('TRACE', 0)))
 DEBUG = bool(int(os.getenv('DEBUG', 0))) or TRACE
@@ -32,8 +30,6 @@ ASAN = bool(int(os.getenv('ASAN', 0)))
 ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 CXX = distutils.ccompiler.get_default_compiler()
 
-# noinspection PyProtectedMember
-warnings.simplefilter('ignore', pyprojecttoml._BetaConfiguration)
 
 def get_cpp_args():
     cpp_args = {}


### PR DESCRIPTION
https://github.com/actions/checkout/releases

This also required:
* Remove deprecated `setuptools` warnings about beta support for `pyproject.toml`
* Revert `build-asan` back to actions/checkout@v3 to solve of GLIBC failures.
* Revert `build-coverage` back to actions/checkout@v3 to solve of GLIBC failures.