### PR TITLE
Build wheels with py3.12 to reduce build time

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3  # TODO: Upgrade to v4 causes GLIBC failures
+        uses: actions/checkout@v3  # TODO: Upgrade to @v4 causes GLIBC failures
         with:
           fetch-depth: 0
 
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3  # TODO: Upgrade to @v4 causes GLIBC failures
         with:
           fetch-depth: 0
 

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Vcpkg
         uses: actions/cache@v3
@@ -101,7 +101,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -159,7 +159,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -190,7 +190,7 @@ jobs:
     needs: build-wheels
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python
         uses: actions/setup-python@v4

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -16,7 +16,7 @@ on:
       - develop
 
 env:
-  PYTHON_VERSION: "3.10"
+  PYTHON_VERSION: "3.12"
 
 jobs:
   build-wheels:

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -134,7 +134,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v3  # TODO: Upgrade to v4 causes GLIBC failures
         with:
           fetch-depth: 0
 

--- a/fastwarc/setup.py
+++ b/fastwarc/setup.py
@@ -14,14 +14,12 @@
 
 import os
 import sys
-import warnings
 
 from Cython.Build import cythonize
 from Cython.Distutils.build_ext import new_build_ext as build_ext
 import distutils.ccompiler
 from distutils.dir_util import copy_tree
 from setuptools import Extension, setup
-from setuptools.config import pyprojecttoml
 
 TRACE = bool(int(os.getenv('TRACE', 0)))
 DEBUG = bool(int(os.getenv('DEBUG', 0))) or TRACE
@@ -30,8 +28,6 @@ ASAN = bool(int(os.getenv('ASAN', 0)))
 ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 CXX = distutils.ccompiler.get_default_compiler()
 
-# noinspection PyProtectedMember
-warnings.simplefilter('ignore', pyprojecttoml._BetaConfiguration)
 
 def get_cpp_args():
     cpp_args = {}

--- a/resiliparse/setup.py
+++ b/resiliparse/setup.py
@@ -17,13 +17,11 @@ import os
 import platform
 import shutil
 import sys
-import warnings
 
 from Cython.Build import cythonize
 from Cython.Distutils.build_ext import new_build_ext as build_ext
 import distutils.ccompiler
 from setuptools import Extension, setup
-from setuptools.config import pyprojecttoml
 
 TRACE = bool(int(os.getenv('TRACE', 0)))
 DEBUG = bool(int(os.getenv('DEBUG', 0))) or TRACE
@@ -32,8 +30,6 @@ ASAN = bool(int(os.getenv('ASAN', 0)))
 ROOT_DIR = os.path.abspath(os.path.dirname(__file__))
 CXX = distutils.ccompiler.get_default_compiler()
 
-# noinspection PyProtectedMember
-warnings.simplefilter('ignore', pyprojecttoml._BetaConfiguration)
 
 def get_cpp_args():
     cpp_args = {}


### PR DESCRIPTION
This pull request contains all changes in #32 plus just one additional change: Build wheels using Py3.12 instead of Py3.10.
* #32 

We try the shift to Python 3.12 because builds take a lot of CI time to build and:
* CPython 3.11 is [~25% faster](https://docs.python.org/3.11/whatsnew/3.11.html) than Python 3.10 and 
* CPython 3.12 is [~5% faster](https://docs.python.org/3.12/whatsnew/3.12.html) than Python 3.11.

### Will these CPython speed increases allow us to save CI build time, especially on macOS?

---
OS and Job Step | CPython 3.10 | CPython 3.12 | difference
--- | --- | --- | ---
Ubuntu Build FastWARC | 3m 51s | 3m 53s | ~
Ubuntu Build Resiliparse | 6m 52s | 6m 59s | ~
Windows Build FastWARC | 6m 19s | 4m 58s | Nice!
Windows Build Resiliparse | 7m 15s | 7m 2s | ~
macOS Build FastWARC | 14m 34s | 10m 1s | Nice!
macOS Build Resiliparse | 23m 3s | 20m 2s | Nice!
