### PR TITLE
Enable build of linux-aarch64 wheels

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -26,9 +26,11 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
     env:
       CIBW_SKIP: "*-musllinux*"
-      CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/chatnoir-eu/resiliparse-manylinux2014_x86_64
+      CIBW_MANYLINUX_X86_64_IMAGE:  ghcr.io/jonded94/resiliparse-manylinux_2_28_x86_64  # replace with ${{ github.repository_owner }}
+      CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/jonded94/resiliparse-manylinux_2_28_aarch64
       CIBW_ARCHS_MACOS: "x86_64 arm64"
-      CIBW_TEST_SKIP: "*-macosx_arm64"    # Apple Silicon wheels cannot be tested
+      CIBW_ARCHS_LINUX: "x86_64 aarch64"
+      CIBW_TEST_SKIP: "*-macosx_arm64 *-manylinux_aarch64"    # Apple Silicon wheels cannot be tested
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: >-
         DYLD_LIBRARY_PATH=$LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
       CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install delvewheel"
@@ -74,6 +76,12 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
 
       - name: Install cibuildwheel
         run: python -m pip install cibuildwheel
@@ -152,7 +160,7 @@ jobs:
   build-coverage:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/chatnoir-eu/resiliparse-manylinux2014_x86_64
+      image: ghcr.io/jonded94/resiliparse-manylinux_2_28_x86_64
     needs: [ build-wheels, build-asan, build-sdist ]
     env:
       TRACE: "1"
@@ -211,8 +219,8 @@ jobs:
           grep -vE "fastwarc|resiliparse" docs/requirements.txt | xargs python -m pip install
 
           PYTHON_ABI="cp${PYTHON_VERSION/./}"
-          find wheelhouse -name "FastWARC-*-${PYTHON_ABI}-*-manylinux*.whl" | xargs -I% python -m pip install "%[all]"
-          find wheelhouse -name "Resiliparse-*-${PYTHON_ABI}-*-manylinux*.whl" | xargs -I% python -m pip install "%[all]"
+          find wheelhouse -name "FastWARC-*-${PYTHON_ABI}-*-manylinux_x86_64.whl" | xargs -I% python -m pip install "%[all]"
+          find wheelhouse -name "Resiliparse-*-${PYTHON_ABI}-*-manylinux_x86_64.whl" | xargs -I% python -m pip install "%[all]"
 
           cd docs
           make html

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -83,16 +83,24 @@ jobs:
         with:
           platforms: all
 
-      - name: Install cibuildwheel
-        run: python -m pip install cibuildwheel
+#      - name: Install cibuildwheel
+#        run: python -m pip install cibuildwheel
 
       - name: Build FastWARC
-        run: python -m cibuildwheel --output-dir wheelhouse fastwarc
+        uses: pypa/cibuildwheel@v2.16.5
+        with:
+          package-dir: fastwarc
+          output-dir: wheelhouse
+        # run: python -m cibuildwheel --output-dir wheelhouse fastwarc
         env:
           CIBW_TEST_COMMAND: python -m pytest --capture=sys --verbose {project}/tests/fastwarc
 
       - name: Build Resiliparse
-        run: python -m cibuildwheel --output-dir wheelhouse resiliparse
+        uses: pypa/cibuildwheel@v2.16.5
+        with:
+          package-dir: resiliparse
+          output-dir: wheelhouse
+        # run: python -m cibuildwheel --output-dir wheelhouse resiliparse
         env:
           CIBW_BEFORE_TEST: >-
             python -c "import glob, platform; open('fastwarc.txt', 'w').write(glob.glob('wheelhouse/FastWARC-*cp' + ''.join(map(str, platform.python_version_tuple()[:2])) + '-*_' + platform.machine().lower() + '.whl')[0])" &&

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -179,7 +179,6 @@ jobs:
   build-asan:
     runs-on: ubuntu-latest
     container:
-      # still old image here since wrong gcc asan toolset was installed in new Dockerfile
       image: ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_x86_64:latest
     env:
       DEBUG: "1"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -26,7 +26,7 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
     env:
       CIBW_SKIP: "*-musllinux*"
-      CIBW_MANYLINUX_X86_64_IMAGE:  ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_x86_64:latest
+      CIBW_MANYLINUX_X86_64_IMAGE: ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_x86_64:latest
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_ARCHS_LINUX: "x86_64"
       CIBW_TEST_SKIP: "*-macosx_arm64"    # Apple Silicon wheels cannot be tested

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -180,7 +180,7 @@ jobs:
     runs-on: ubuntu-latest
     container:
       # still old image here since wrong gcc asan toolset was installed in new Dockerfile
-      image: ghcr.io/chatnoir-eu/resiliparse-manylinux2014_x86_64:latest
+      image: ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_x86_64:latest
     env:
       DEBUG: "1"
       ASAN: "1"

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -27,10 +27,9 @@ jobs:
     env:
       CIBW_SKIP: "*-musllinux*"
       CIBW_MANYLINUX_X86_64_IMAGE:  ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_x86_64:latest
-      CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_aarch64:latest
       CIBW_ARCHS_MACOS: "x86_64 arm64"
-      CIBW_ARCHS_LINUX: "x86_64 aarch64"
-      CIBW_TEST_SKIP: "*-macosx_arm64 *-manylinux_aarch64"    # Apple Silicon wheels cannot be tested
+      CIBW_ARCHS_LINUX: "x86_64"
+      CIBW_TEST_SKIP: "*-macosx_arm64"    # Apple Silicon wheels cannot be tested
       CIBW_REPAIR_WHEEL_COMMAND_MACOS: >-
         DYLD_LIBRARY_PATH=$LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}
       CIBW_BEFORE_BUILD_WINDOWS: "python -m pip install delvewheel"
@@ -77,21 +76,11 @@ jobs:
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Set up QEMU
-        if: runner.os == 'Linux'
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: all
-
-#      - name: Install cibuildwheel
-#        run: python -m pip install cibuildwheel
-
       - name: Build FastWARC
         uses: pypa/cibuildwheel@v2.16.5
         with:
           package-dir: fastwarc
           output-dir: wheelhouse
-        # run: python -m cibuildwheel --output-dir wheelhouse fastwarc
         env:
           CIBW_TEST_COMMAND: python -m pytest --capture=sys --verbose {project}/tests/fastwarc
 
@@ -100,7 +89,55 @@ jobs:
         with:
           package-dir: resiliparse
           output-dir: wheelhouse
-        # run: python -m cibuildwheel --output-dir wheelhouse resiliparse
+        env:
+          CIBW_BEFORE_TEST: >-
+            python -c "import glob, platform; open('fastwarc.txt', 'w').write(glob.glob('wheelhouse/FastWARC-*cp' + ''.join(map(str, platform.python_version_tuple()[:2])) + '-*_' + platform.machine().lower() + '.whl')[0])" &&
+            python -m pip install -r fastwarc.txt
+          CIBW_TEST_COMMAND: python -m pytest --capture=sys --verbose {project}/tests/resiliparse
+
+      - name: Upload Wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: ./wheelhouse/*.whl
+
+  build-wheels-qemu:
+    runs-on: ubuntu-latest
+    env:
+      CIBW_SKIP: "*-musllinux*"
+      CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_aarch64:latest
+      CIBW_ARCHS_LINUX: "aarch64"
+      CIBW_TEST_SKIP: "*-manylinux_aarch64"
+      # https://github.com/pypa/cibuildwheel/issues/1771#issuecomment-1973003145
+      CIBW_CONTAINER_ENGINE: "docker; create_args: --platform linux/arm64/v8"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
+
+      - name: Build FastWARC
+        uses: pypa/cibuildwheel@v2.16.5
+        with:
+          package-dir: fastwarc
+          output-dir: wheelhouse
+        env:
+          CIBW_TEST_COMMAND: python -m pytest --capture=sys --verbose {project}/tests/fastwarc
+
+      - name: Build Resiliparse
+        uses: pypa/cibuildwheel@v2.16.5
+        with:
+          package-dir: resiliparse
+          output-dir: wheelhouse
         env:
           CIBW_BEFORE_TEST: >-
             python -c "import glob, platform; open('fastwarc.txt', 'w').write(glob.glob('wheelhouse/FastWARC-*cp' + ''.join(map(str, platform.python_version_tuple()[:2])) + '-*_' + platform.machine().lower() + '.whl')[0])" &&
@@ -142,7 +179,8 @@ jobs:
   build-asan:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_x86_64:latest
+      # still old image here since wrong gcc asan toolset was installed in new Dockerfile
+      image: ghcr.io/chatnoir-eu/resiliparse-manylinux2014_x86_64:latest
     env:
       DEBUG: "1"
       ASAN: "1"
@@ -244,7 +282,7 @@ jobs:
   publish-wheels:
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [ build-wheels, build-sdist, build-documentation ]
+    needs: [ build-wheels, build-wheels-qemu, build-sdist, build-documentation ]
     steps:
       - name: Download Wheels
         uses: actions/download-artifact@v3

--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -26,8 +26,8 @@ jobs:
         os: [ ubuntu-latest, windows-latest, macOS-latest ]
     env:
       CIBW_SKIP: "*-musllinux*"
-      CIBW_MANYLINUX_X86_64_IMAGE:  ghcr.io/jonded94/resiliparse-manylinux_2_28_x86_64  # replace with ${{ github.repository_owner }}
-      CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/jonded94/resiliparse-manylinux_2_28_aarch64
+      CIBW_MANYLINUX_X86_64_IMAGE:  ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_x86_64:latest
+      CIBW_MANYLINUX_AARCH64_IMAGE: ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_aarch64:latest
       CIBW_ARCHS_MACOS: "x86_64 arm64"
       CIBW_ARCHS_LINUX: "x86_64 aarch64"
       CIBW_TEST_SKIP: "*-macosx_arm64 *-manylinux_aarch64"    # Apple Silicon wheels cannot be tested
@@ -142,7 +142,7 @@ jobs:
   build-asan:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/chatnoir-eu/resiliparse-manylinux2014_x86_64
+      image: ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_x86_64:latest
     env:
       DEBUG: "1"
       ASAN: "1"
@@ -168,7 +168,7 @@ jobs:
   build-coverage:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/jonded94/resiliparse-manylinux_2_28_x86_64
+      image: ghcr.io/chatnoir-eu/resiliparse-manylinux_2_28_x86_64:latest
     needs: [ build-wheels, build-asan, build-sdist ]
     env:
       TRACE: "1"


### PR DESCRIPTION
Currently, only Mac Intel/ARM, Windows x86_64 and Linux x86_64 wheels are being built in this repository.

It would be nice if Linux ARM wheels could also be available, for example:

- native Docker containers on Mac
- modern ARM-based EC2 instances on AWS
- other ARM-native machines

For that I prepared this PR.

**Disadvantages:**

*libc requirements*

Because of 
- https://github.com/grpc/grpc/issues/33734
- https://github.com/grpc/grpc/issues/30218

I was unable to get this to work with `manylinux2014` and had to switch all the way to `2_28` since `2_24` is deprecated and EOL.

This obviously has the implication that the wheel no longer consumable by OS's that have a libc < `2_28`. This should not be of concern for ARM machines at least since one could expect that they run on relatively new hardware/OS's anyways. Don't know how you feel about that though! One could of course build Linux x86 wheels on the older `manylinux` version, but that would slightly increase complexity in the Dockerfile.

*CI times*

I noticed a rough ~5x increase of CI times since all the ARM Wheel builds and tests are run through QEMU which is notoriously slow.

