### PR TITLE
Move to gcc-toolset-12-libasan-devel in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/pypa/manylinux_2_28_${TARGET_ARCH}:latest
 
 RUN set -x \
     && yum install -y \
-          gcc-toolset-10-libasan-devel \
+          gcc-toolset-12-libasan-devel \
           lz4-devel \
           zlib-devel
 


### PR DESCRIPTION
Move to gcc-toolset-12-libasan-devel  since manylinux_2_28 per defaul is using gcc 12.

Is required to let job `build-asan` also use new 2_28 manylinux image.